### PR TITLE
Removed footer properties from template document types

### DIFF
--- a/DD/Views/GeneralContentPage.cshtml
+++ b/DD/Views/GeneralContentPage.cshtml
@@ -76,6 +76,6 @@
     </div>
 </div>
 <div class="mt-3">
-    @await Html.PartialAsync("Partials/blocklist/_socialMediaItems", Model.FooterSocialMediaItems)
+    @await Html.PartialAsync("Partials/blocklist/_socialMediaItems")
 </div>
 

--- a/DD/Views/LandingPage.cshtml
+++ b/DD/Views/LandingPage.cshtml
@@ -41,5 +41,5 @@
 </div>
 <div class="mt-3 p-5" style="">
 	@await Html.PartialAsync("Partials/homePage/_footer")
-	@await Html.PartialAsync("Partials/blocklist/_socialMediaItems", Model.FooterSocialMediaItems)
+	@await Html.PartialAsync("Partials/blocklist/_socialMediaItems")
 </div>

--- a/DD/Views/Partials/blocklist/_socialMediaItems.cshtml
+++ b/DD/Views/Partials/blocklist/_socialMediaItems.cshtml
@@ -1,4 +1,4 @@
-@inherits Umbraco.Cms.Web.Common.Views.UmbracoViewPage<IEnumerable<BlockListItem>>;
+@inherits Umbraco.Cms.Web.Common.Views.UmbracoViewPage<object>;
 @using ContentModels = Umbraco.Cms.Web.Common.PublishedModels;
 @using Umbraco.Cms.Core.Models.Blocks;
 @{
@@ -10,12 +10,16 @@
     // Get Default Social Media Properties
     var defaultSocialMediaNode = rootNode.Children.FirstOrDefault(x => x.Name == DefaultSocialMediaNodeName);
     // Get default social media items
-    IEnumerable<BlockListItem> socials = Model?.ToList() ?? Enumerable.Empty<BlockListItem>();
+    IEnumerable<BlockListItem> socials;
     IEnumerable<BlockListItem> defaultSocials = defaultSocialMediaNode?.Value<IEnumerable<BlockListItem>>(DSMIN) ?? Enumerable.Empty<BlockListItem>();
 
-    if (!socials.Any())
+    if (Model is null || Model is not IFooterProperties)
     {
         socials = defaultSocials.ToList();
+    }else{
+        // Get social media items from model
+        var socialsList= ((IFooterProperties)Model)?.FooterSocialMediaItems?.ToList() ?? Enumerable.Empty<BlockListItem>();
+        socials =socialsList.Any() ? socialsList : defaultSocials;
     }
 }
 

--- a/DD/Views/Partials/homePage/_footer.cshtml
+++ b/DD/Views/Partials/homePage/_footer.cshtml
@@ -1,4 +1,4 @@
-﻿@inherits Umbraco.Cms.Web.Common.Views.UmbracoViewPage<IFooterProperties>;
+﻿@inherits Umbraco.Cms.Web.Common.Views.UmbracoViewPage<object>;
 @using ContentModels = Umbraco.Cms.Web.Common.PublishedModels;
 @using Umbraco.Cms.Core.Models.Blocks;
 @{
@@ -14,17 +14,19 @@
     var defaultFooterTitle = defaultFooterNode?.Value<string>(FooterTitlePropertyName) ?? "Contacto y Ubicaciones.";
     var defaultBlocksList = defaultFooterNode?.Value<IEnumerable<BlockListItem>>(FooterItemsPropertyName);
 
-    var footerTitle = string.Empty;
-    footerTitle = string.IsNullOrEmpty(Model?.FooterTitle?.ToString()) ? defaultFooterTitle : Model.FooterTitle.ToString();
-
     List<BlockListItem> blocksList;
-    if (Model is null)
+    var footerTitle = string.Empty;
+
+    if (Model is null || Model is not IFooterProperties)
     {
-        blocksList = defaultBlocksList?.ToList();
+        blocksList = defaultBlocksList?.ToList() ?? [];
+        footerTitle = defaultFooterTitle ?? string.Empty;
     }
     else
     {
-            var currentModelList = (Model.FooterItems is not null && Model.FooterItems.Any()) ? Model.FooterItems.ToList() : [];
+            IFooterProperties model = (IFooterProperties)Model;
+            footerTitle = string.IsNullOrEmpty(model?.FooterTitle?.ToString()) ? defaultFooterTitle : model.FooterTitle.ToString();
+            var currentModelList = (model.FooterItems is not null && model.FooterItems.Any()) ? model.FooterItems.ToList() : [];
             var defaultFooterItems = defaultBlocksList.ToList();   
             if( currentModelList.Any() ){
                 blocksList = currentModelList;

--- a/DD/umbraco/models/GeneralContentPage.generated.cs
+++ b/DD/umbraco/models/GeneralContentPage.generated.cs
@@ -20,7 +20,7 @@ namespace Umbraco.Cms.Web.Common.PublishedModels
 {
 	/// <summary>General Content Page</summary>
 	[PublishedModel("generalContentPage")]
-	public partial class GeneralContentPage : PublishedContentModel, IFooterProperties, IHeaderProperties
+	public partial class GeneralContentPage : PublishedContentModel, IHeaderProperties
 	{
 		// helpers
 #pragma warning disable 0109 // new is redundant
@@ -56,30 +56,6 @@ namespace Umbraco.Cms.Web.Common.PublishedModels
 		[global::System.Diagnostics.CodeAnalysis.MaybeNull]
 		[ImplementPropertyType("contentPageBlocks")]
 		public virtual global::Umbraco.Cms.Core.Models.Blocks.BlockListModel ContentPageBlocks => this.Value<global::Umbraco.Cms.Core.Models.Blocks.BlockListModel>(_publishedValueFallback, "contentPageBlocks");
-
-		///<summary>
-		/// footer Items
-		///</summary>
-		[global::System.CodeDom.Compiler.GeneratedCodeAttribute("Umbraco.ModelsBuilder.Embedded", "13.0.3+a0f3c15")]
-		[global::System.Diagnostics.CodeAnalysis.MaybeNull]
-		[ImplementPropertyType("footerItems")]
-		public virtual global::Umbraco.Cms.Core.Models.Blocks.BlockListModel FooterItems => global::Umbraco.Cms.Web.Common.PublishedModels.FooterProperties.GetFooterItems(this, _publishedValueFallback);
-
-		///<summary>
-		/// footer Social Media Items
-		///</summary>
-		[global::System.CodeDom.Compiler.GeneratedCodeAttribute("Umbraco.ModelsBuilder.Embedded", "13.0.3+a0f3c15")]
-		[global::System.Diagnostics.CodeAnalysis.MaybeNull]
-		[ImplementPropertyType("footerSocialMediaItems")]
-		public virtual global::Umbraco.Cms.Core.Models.Blocks.BlockListModel FooterSocialMediaItems => global::Umbraco.Cms.Web.Common.PublishedModels.FooterProperties.GetFooterSocialMediaItems(this, _publishedValueFallback);
-
-		///<summary>
-		/// footerTitle: Enter the footer Title
-		///</summary>
-		[global::System.CodeDom.Compiler.GeneratedCodeAttribute("Umbraco.ModelsBuilder.Embedded", "13.0.3+a0f3c15")]
-		[global::System.Diagnostics.CodeAnalysis.MaybeNull]
-		[ImplementPropertyType("footerTitle")]
-		public virtual global::Umbraco.Cms.Core.Strings.IHtmlEncodedString FooterTitle => global::Umbraco.Cms.Web.Common.PublishedModels.FooterProperties.GetFooterTitle(this, _publishedValueFallback);
 
 		///<summary>
 		/// Header Image 2

--- a/DD/umbraco/models/LandingPage.generated.cs
+++ b/DD/umbraco/models/LandingPage.generated.cs
@@ -20,7 +20,7 @@ namespace Umbraco.Cms.Web.Common.PublishedModels
 {
 	/// <summary>Landing Page</summary>
 	[PublishedModel("landingPage")]
-	public partial class LandingPage : PublishedContentModel, IFooterProperties, IHeaderProperties, IHomeRedirectButtonProperties, IRichTextHeadlineRow, ISearchComboProperties
+	public partial class LandingPage : PublishedContentModel, IHeaderProperties, IHomeRedirectButtonProperties, IRichTextHeadlineRow, ISearchComboProperties
 	{
 		// helpers
 #pragma warning disable 0109 // new is redundant
@@ -80,30 +80,6 @@ namespace Umbraco.Cms.Web.Common.PublishedModels
 		[global::System.Diagnostics.CodeAnalysis.MaybeNull]
 		[ImplementPropertyType("richTextAndImages")]
 		public virtual global::Umbraco.Cms.Core.Models.Blocks.BlockListModel RichTextAndImages => this.Value<global::Umbraco.Cms.Core.Models.Blocks.BlockListModel>(_publishedValueFallback, "richTextAndImages");
-
-		///<summary>
-		/// footer Items
-		///</summary>
-		[global::System.CodeDom.Compiler.GeneratedCodeAttribute("Umbraco.ModelsBuilder.Embedded", "13.0.3+a0f3c15")]
-		[global::System.Diagnostics.CodeAnalysis.MaybeNull]
-		[ImplementPropertyType("footerItems")]
-		public virtual global::Umbraco.Cms.Core.Models.Blocks.BlockListModel FooterItems => global::Umbraco.Cms.Web.Common.PublishedModels.FooterProperties.GetFooterItems(this, _publishedValueFallback);
-
-		///<summary>
-		/// footer Social Media Items
-		///</summary>
-		[global::System.CodeDom.Compiler.GeneratedCodeAttribute("Umbraco.ModelsBuilder.Embedded", "13.0.3+a0f3c15")]
-		[global::System.Diagnostics.CodeAnalysis.MaybeNull]
-		[ImplementPropertyType("footerSocialMediaItems")]
-		public virtual global::Umbraco.Cms.Core.Models.Blocks.BlockListModel FooterSocialMediaItems => global::Umbraco.Cms.Web.Common.PublishedModels.FooterProperties.GetFooterSocialMediaItems(this, _publishedValueFallback);
-
-		///<summary>
-		/// footerTitle: Enter the footer Title
-		///</summary>
-		[global::System.CodeDom.Compiler.GeneratedCodeAttribute("Umbraco.ModelsBuilder.Embedded", "13.0.3+a0f3c15")]
-		[global::System.Diagnostics.CodeAnalysis.MaybeNull]
-		[ImplementPropertyType("footerTitle")]
-		public virtual global::Umbraco.Cms.Core.Strings.IHtmlEncodedString FooterTitle => global::Umbraco.Cms.Web.Common.PublishedModels.FooterProperties.GetFooterTitle(this, _publishedValueFallback);
 
 		///<summary>
 		/// Header Image 2


### PR DESCRIPTION
* Made it so that the footer and social media component work without the calling template having IFooterProperties as part of its model